### PR TITLE
Alignment not working #24 - Exposing the Image and Video Alignment Formats

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,3 +19,7 @@ export { default as BlotSpec } from './specs/BlotSpec';
 export { default as ImageSpec } from './specs/ImageSpec';
 export { default as UnclickableBlotSpec } from './specs/UnclickableBlotSpec';
 export { default as IframeVideoSpec } from './specs/IframeVideoSpec';
+
+// formats
+export { ImageAlign as ImageAlignFormat } from './actions/align/AlignFormats';
+export { IframeAlign as IframeAlignFormat } from './actions/align/AlignFormats';


### PR DESCRIPTION
If I understood the issue  [Alignment not working #24] correctly,
 in order to get the alignment working with ReactQuill2-New one needs to re-register the alignment formats on the Quill instance from react-quill2.

This trivial PR is about exposing the the alignment formats for images and videos.